### PR TITLE
Fix operators for 3D inputs

### DIFF
--- a/src/nodes/batchnormalization.h
+++ b/src/nodes/batchnormalization.h
@@ -70,8 +70,9 @@ class BatchNormalization : public Node {
 		const Tensor *input = get_input_tensor(0);
 		const Tensor *scale = get_input_tensor(1);
 		const Tensor *bias  = get_input_tensor(2);
-		int batch_size =input->data_dim[0]; 
-		int num_chan =input->data_dim[1]; 
+               bool has_batch = input->rank() == 3 ? false : true;
+               int batch_size = has_batch ? input->data_dim[0] : 1;
+               int num_chan = has_batch ? input->data_dim[1] : input->data_dim[0];
 		std::string type = input->data_type_str();
 
 		dst << "\t/* BatchNormalization" << std::endl;
@@ -82,20 +83,22 @@ class BatchNormalization : public Node {
 		if( sqrt_var_offline  == false)
 			INDT_1 << "float epsilon = " << epsilon << ";" <<std::endl;
 
-		dst<<"\t" << "for( int32_t b=0; b<" << batch_size << "; b++ ) {" << std::endl;
-		dst<<"\t" << "for( int32_t c=0; c<" << num_chan << "; c++ ) {" << std::endl;
+               if( has_batch )
+                       dst<<"\t" << "for( int32_t b=0; b<" << batch_size << "; b++ ) {" << std::endl;
+               dst<<"\t" << "for( int32_t c=0; c<" << num_chan << "; c++ ) {" << std::endl;
 
 		// create the indexing string for picking out an element in input/output
-		std::string idxs = "[b][c]";
-		for( unsigned i = 2; i<input->data_dim.size(); i++)
-			idxs += "[i" + std::to_string(i) + "]";
+               std::string idxs = has_batch ? "[b][c]" : "[c]";
+               unsigned start = has_batch ? 2 : 1;
+               for( unsigned i = start; i<input->data_dim.size(); i++)
+                       idxs += "[i" + std::to_string(i) + "]";
 
 
 		// Loop over data dimensions
-		for( unsigned i = 2; i<input->data_dim.size(); i++) {
-			std::string idx = "i" + std::to_string(i);
+               for( unsigned i = start; i<input->data_dim.size(); i++) {
+                       std::string idx = "i" + std::to_string(i);
 			dst << "\t" << "for( uint32_t " << idx << "=0; ";
-			dst <<               idx << "<" << input->data_dim[i] << "; ";
+                        dst <<               idx << "<" << input->data_dim[i] << "; ";
 			dst <<               idx <<"++ ) {" << std::endl;
 		}
 
@@ -113,11 +116,12 @@ class BatchNormalization : public Node {
 		    dst << " + bias[c]";
 		dst << ";" << std::endl;
 
-		for( unsigned i = 2; i<input->data_dim.size(); i++)
-			dst << "\t}" << std::endl;
+                for( unsigned i = start; i<input->data_dim.size(); i++)
+                        dst << "\t}" << std::endl;
 
-		dst<<"\t" << "}" << std::endl;
-		dst<<"\t" << "}" << std::endl;
+                dst<<"\t" << "}" << std::endl;
+                if( has_batch )
+                        dst<<"\t" << "}" << std::endl;
 	}
 
 	// TODO: this could be useful elsewhere too

--- a/src/nodes/convtranspose.cc
+++ b/src/nodes/convtranspose.cc
@@ -164,9 +164,10 @@ void ConvTranspose::resolve_convtranspose_pads(void)
 
 std::vector<int> ConvTranspose::calculate_output_size(void)
 {
-	std::vector<int> shape;
-	shape.push_back(x->data_dim[0]); // batch
-	shape.push_back(w->data_dim[1] * group); // maps
+        std::vector<int> shape;
+        bool has_batch = x->rank() == kernel_shape.size() + 2;
+        shape.push_back(has_batch ? x->data_dim[0] : 1);
+        shape.push_back(w->data_dim[1] * group);
 	for( auto s : output_shape )
 		shape.push_back(s);
 	return shape;
@@ -259,15 +260,16 @@ void ConvTranspose::print_header_info_comment(std::ostream &dst) const
  */
 void ConvTranspose::print_calculation( std::ostream &dst) const
 {
-	unsigned n_data_dims = x->data_dim.size() -2;
-	unsigned batch_size = x->data_dim[0];
-	unsigned channels = x->data_dim[1];
+        unsigned n_data_dims = kernel_shape.size();
+        bool has_batch = x->rank() == n_data_dims + 2;
+        unsigned batch_size = has_batch ? x->data_dim[0] : 1;
+        unsigned channels = has_batch ? x->data_dim[1] : x->data_dim[0];
 	unsigned maps=y->data_dim[1];
 
 	// Create various indexing strings. This makes generating the loops much cleaner.
-	std::string x_idx = "[b][c]";
-	std::string w_idx = "[c][m]"; // TODO: in case of groups, change c to something else
-	std::string y_idx = "[b][m]";
+        std::string x_idx = has_batch? "[b][c]" : "[c]";
+        std::string w_idx = "[c][m]";
+        std::string y_idx = has_batch? "[b][m]" : "[m]";
 	for( unsigned i = 0; i<n_data_dims; i++) {
 	std::string i_str = std::to_string(i);
 		x_idx += "[i" + i_str + "]";
@@ -279,8 +281,9 @@ void ConvTranspose::print_calculation( std::ostream &dst) const
 	INDT_1 << "memset(y, 0," << y->data_num_elem()*y->data_elem_size() << ");" << std::endl << std::endl;
 
 	// Create the loops over batches and maps (output channels).
-	INDT_1 << "for( uint32_t b=0; b<" << batch_size << "; b++ ) {" << std::endl;
-	INDT_1 << "for( uint32_t m=0; m<" << maps << "; m++) {" << std::endl;
+        if( has_batch )
+                INDT_1 << "for( uint32_t b=0; b<" << batch_size << "; b++ ) {" << std::endl;
+        INDT_1 << "for( uint32_t m=0; m<" << maps << "; m++) {" << std::endl;
 
 	// loop inputs
 	for( unsigned i = 0; i<n_data_dims; i++) {
@@ -342,13 +345,15 @@ void ConvTranspose::print_calculation( std::ostream &dst) const
 		INDT_2 << "} /* o */" << std::endl;
 
 	// close loops over batches and output channels
-	INDT_1 << "} /* m */" << std::endl;
-	INDT_1 << "} /* b */" << std::endl;
+        INDT_1 << "} /* m */" << std::endl;
+        if( has_batch )
+                INDT_1 << "} /* b */" << std::endl;
     
     // YK: bias should be added only once
     if( b ) {
         // Create the loops over batches and maps (output channels).
-        INDT_1 << "for( uint32_t b=0; b<" << batch_size << "; b++ ) {" << std::endl;
+        if( has_batch )
+                INDT_1 << "for( uint32_t b=0; b<" << batch_size << "; b++ ) {" << std::endl;
         INDT_2 << "for( uint32_t m=0; m<" << maps << "; m++) {" << std::endl;
         for( unsigned i = 0; i<n_data_dims; i++) {
             std::string i_str = std::to_string(i);

--- a/src/nodes/globalaveragepool.h
+++ b/src/nodes/globalaveragepool.h
@@ -15,28 +15,30 @@ class GlobalAveragePool : public Node {
 	/* Body of the node implementing function */
 	virtual void print(std::ostream &dst) const override
 	{
-		const Tensor *X=get_input_tensor(0);
-		int batch_size = X->data_dim[0];
-		int num_channels = X->data_dim[1];
+               const Tensor *X=get_input_tensor(0);
+               bool has_batch = X->rank() > 3 ? true : (X->rank() == 3 ? false : true);
+               int batch_size = has_batch ? X->data_dim[0] : 1;
+               int num_channels = has_batch ? X->data_dim[1] : X->data_dim[0];
 
 		dst << "\t/* GlobalAveragePool */" << std::endl;
-		dst<<"\t"  << "for( int32_t b=0; b<" << batch_size << "; b++ ) {" << std::endl;
-		dst<<"\t"  << "for( int32_t c=0; c<" << num_channels << "; c++ ) {" << std::endl;
+               if( has_batch )
+                       dst<<"\t"  << "for( int32_t b=0; b<" << batch_size << "; b++ ) {" << std::endl;
+               dst<<"\t"  << "for( int32_t c=0; c<" << num_channels << "; c++ ) {" << std::endl;
 
 		// TODO: float16, double? accuracy vs speed...
 		dst << "\t\tfloat dimsum=0.0f;" << std::endl;
 
 		int dim_num_elem=1; // number of elements averaged over
-		std::string in_idx_string = "input[b][c]"; // start of the input element access string
-		std::string out_idx_string = "output[b][c]"; // start of the input element access string
+               std::string in_idx_string = has_batch ? "input[b][c]" : "input[c]";
+               std::string out_idx_string = has_batch ? "output[b][c]" : "output[c]";
 
-		for( unsigned dim = 2; dim < X->data_dim.size(); dim ++ ) {
-			int dim_size = X->data_dim[dim];
-			dim_num_elem *= dim_size;
-
-			std::string dim_var = "d" + std::to_string(dim-2);
-			in_idx_string += "[" + dim_var + "]";
-			out_idx_string += "[0]";
+               unsigned start = has_batch ? 2 : 1;
+               for( unsigned dim = start; dim < X->data_dim.size(); dim ++ ) {
+                       int dim_size = X->data_dim[dim];
+                       dim_num_elem *= dim_size;
+                       std::string dim_var = "d" + std::to_string(dim-start);
+                       in_idx_string += "[" + dim_var + "]";
+                       out_idx_string += "[0]";
 			dst << "\t\t" << "for( int32_t " << dim_var <<" = 0; ";
 			dst <<            dim_var << "<" << dim_size << "; ";
 			dst <<            dim_var<<"++ ) {" << std::endl;
@@ -44,15 +46,16 @@ class GlobalAveragePool : public Node {
 
 			dst << "\t\t\tdimsum +=  " << in_idx_string << ";" << std::endl;
 
-		for( unsigned dim = 2; dim < X->data_dim.size(); dim ++ ) {
-			dst << "\t\t}" << std::endl;
-		}
+               for( unsigned dim = start; dim < X->data_dim.size(); dim ++ ) {
+                       dst << "\t\t}" << std::endl;
+               }
 
 		dst << "\t\t" << out_idx_string << " = dimsum / " << dim_num_elem << ";" << std::endl; 
 
 		// close loop over b and c
-		dst<<"\t}" << std::endl;
-		dst<<"\t}" << std::endl;
+               dst<<"\t}" << std::endl;
+               if( has_batch )
+                       dst<<"\t}" << std::endl;
 	}
 
 
@@ -65,11 +68,13 @@ class GlobalAveragePool : public Node {
 
 
 		/* Create output tensors */
-		Tensor *rv = new Tensor;
-		rv->data_dim.push_back(X->data_dim[0]);
-		rv->data_dim.push_back(X->data_dim[1]);
-		for( unsigned i=2; i<X->data_dim.size(); i++)
-			rv->data_dim.push_back(1);
+               Tensor *rv = new Tensor;
+               bool has_batch = X->rank() > 3 ? true : (X->rank() == 3 ? false : true);
+               rv->data_dim.push_back(has_batch ? X->data_dim[0] : 1);
+               rv->data_dim.push_back(has_batch ? X->data_dim[1] : X->data_dim[0]);
+               unsigned start = has_batch ? 2 : 1;
+               for( unsigned i=start; i<X->data_dim.size(); i++)
+                        rv->data_dim.push_back(1);
 		rv->data_type = X->data_type;
 		register_output(rv, "output");
 	}

--- a/src/nodes/globalmaxpool.h
+++ b/src/nodes/globalmaxpool.h
@@ -8,26 +8,29 @@ class GlobalMaxPool : public Node {
 
 	virtual void print(std::ostream &dst) const override
 	{
-		const Tensor *X=get_input_tensor(0);
-		int batch_size = X->data_dim[0];
-		int num_channels = X->data_dim[1];
+               const Tensor *X=get_input_tensor(0);
+               bool has_batch = X->rank() == 3 ? false : true;
+               int batch_size = has_batch ? X->data_dim[0] : 1;
+               int num_channels = has_batch ? X->data_dim[1] : X->data_dim[0];
 
 		dst << "\t/* GlobalMaxPool */" << std::endl;
-		dst << "\tfor( int32_t b=0; b<" << batch_size << "; b++ ) {" << std::endl;
-		dst << "\tfor( int32_t c=0; c<" << num_channels << "; c++ ) {" << std::endl;
+               if( has_batch )
+                       dst << "\tfor( int32_t b=0; b<" << batch_size << "; b++ ) {" << std::endl;
+               dst << "\tfor( int32_t c=0; c<" << num_channels << "; c++ ) {" << std::endl;
 
 		// Initialize max_value to a very small value
 		dst << "\t\tfloat max_value = -FLT_MIN;" << std::endl;
 
-		std::string in_idx_string = "input[b][c]";  // Start of input element access
-		std::string out_idx_string = "output[b][c]"; // Output tensor index
+               std::string in_idx_string = has_batch ? "input[b][c]" : "input[c]";
+               std::string out_idx_string = has_batch ? "output[b][c]" : "output[c]";
 
 		// Iterate over spatial dimensions
-		for( unsigned dim = 2; dim < X->data_dim.size(); dim ++ ) {
-			int dim_size = X->data_dim[dim];
-			std::string dim_var = "d" + std::to_string(dim-2);
-			in_idx_string += "[" + dim_var + "]";
-			out_idx_string += "[0]";
+               unsigned start = has_batch ? 2 : 1;
+               for( unsigned dim = start; dim < X->data_dim.size(); dim ++ ) {
+                       int dim_size = X->data_dim[dim];
+                       std::string dim_var = "d" + std::to_string(dim-start);
+                       in_idx_string += "[" + dim_var + "]";
+                       out_idx_string += "[0]";
 
 			dst << "\t\tfor( int32_t " << dim_var << " = 0; " 
 			    << dim_var << " < " << dim_size << "; " 
@@ -38,16 +41,17 @@ class GlobalMaxPool : public Node {
 		dst << "\t\t\tmax_value = MAX(max_value, " << in_idx_string << ");" << std::endl;
 
 		// Close loops for spatial dimensions
-		for( unsigned dim = 2; dim < X->data_dim.size(); dim ++ ) {
-			dst << "\t\t}" << std::endl;
-		}
+               for( unsigned dim = start; dim < X->data_dim.size(); dim ++ ) {
+                       dst << "\t\t}" << std::endl;
+               }
 
 		// Assign the max value to output
 		dst << "\t\t" << out_idx_string << " = max_value;" << std::endl;
 
 		// Close loop over batch and channel
-		dst << "\t}" << std::endl;
-		dst << "\t}" << std::endl;
+               dst << "\t}" << std::endl;
+               if( has_batch )
+                       dst << "\t}" << std::endl;
 	}
 
 	virtual void resolve(void) override
@@ -58,11 +62,13 @@ class GlobalMaxPool : public Node {
 			ERROR("Incorrect input for node"); 
 
 		/* Create output tensors */
-		Tensor *rv = new Tensor;
-		rv->data_dim.push_back(X->data_dim[0]); // Batch dimension
-		rv->data_dim.push_back(X->data_dim[1]); // Channel dimension
-		for( unsigned i=2; i<X->data_dim.size(); i++)
-			rv->data_dim.push_back(1);  // Reduce spatial dimensions to 1
+               Tensor *rv = new Tensor;
+               bool has_batch = X->rank() == 3 ? false : true;
+               rv->data_dim.push_back(has_batch ? X->data_dim[0] : 1);
+               rv->data_dim.push_back(has_batch ? X->data_dim[1] : X->data_dim[0]);
+               unsigned start = has_batch ? 2 : 1;
+               for( unsigned i=start; i<X->data_dim.size(); i++)
+                        rv->data_dim.push_back(1);  // Reduce spatial dimensions to 1
 		rv->data_type = X->data_type;
 		register_output(rv, "output");
 	}

--- a/src/nodes/instancenorm.cc
+++ b/src/nodes/instancenorm.cc
@@ -52,17 +52,19 @@ void InstanceNormalization::print(std::ostream &dst) const
 
 	INDT_1 << "float epsilon = " << epsilon << ";" << std::endl;
 
-	int batch_size =input->data_dim[0];
-	int num_chan =input->data_dim[1];
+        bool has_batch = input->rank() == 3 ? false : true;
+        int batch_size = has_batch ? input->data_dim[0] : 1;
+        int num_chan = has_batch ? input->data_dim[1] : input->data_dim[0];
 	std::string type = input->data_type_str();
 
 
-	INDT_1 << "for( int32_t b=0; b<" << batch_size << "; b++ ) {" << std::endl;
-	INDT_1 << "for( int32_t c=0; c<" << num_chan << "; c++ ) {" << std::endl;
+        if( has_batch )
+                INDT_1 << "for( int32_t b=0; b<" << batch_size << "; b++ ) {" << std::endl;
+        INDT_1 << "for( int32_t c=0; c<" << num_chan << "; c++ ) {" << std::endl;
 
 
-	std::string idxs = "[b][c]";
-	unsigned instance_size=1;
+        std::string idxs = has_batch ? "[b][c]" : "[c]";
+        unsigned instance_size=1;
 
 	// First calculate mean & variance over instance
 	// Other ways of calculating variance:
@@ -70,11 +72,12 @@ void InstanceNormalization::print(std::ostream &dst) const
 	dst << std::endl;
 	INDT_2 << type << " mean =  0;" << std::endl;
 	INDT_2 << type << " sqmean =  0;" << std::endl;
-	for( unsigned i = 2; i<input->data_dim.size(); i++) {
-		std::string idx = "i" + std::to_string(i);
-		INDT_2 << "for( uint32_t " << idx << "=0; ";
-		dst <<            idx << "<" << input->data_dim[i] << "; ";
-		dst <<            idx <<"++ ) {" << std::endl;
+        unsigned start = has_batch ? 2 : 1;
+        for( unsigned i = start; i<input->data_dim.size(); i++) {
+                std::string idx = "i" + std::to_string(i);
+                INDT_2 << "for( uint32_t " << idx << "=0; ";
+                dst <<            idx << "<" << input->data_dim[i] << "; ";
+                dst <<            idx <<"++ ) {" << std::endl;
 
 		idxs += "[i" + std::to_string(i) + "]";
 		instance_size *= input->data_dim[i];
@@ -83,8 +86,8 @@ void InstanceNormalization::print(std::ostream &dst) const
 	 INDT_3 << "mean += d;" << std::endl;
 	 INDT_3 << "sqmean += d*d;" << std::endl;
 
-	for( unsigned i = 2; i<input->data_dim.size(); i++)
-		INDT_2 << "}" << std::endl;
+        for( unsigned i = start; i<input->data_dim.size(); i++)
+                INDT_2 << "}" << std::endl;
 
 	INDT_2 << "mean /= " << instance_size << ";" << std::endl;
 	INDT_2 << "sqmean /= " << instance_size << ";" << std::endl;
@@ -93,22 +96,23 @@ void InstanceNormalization::print(std::ostream &dst) const
 
 
 	// Now loop over the instance again, normalizing
-	for( unsigned i = 2; i<input->data_dim.size(); i++) {
-		std::string idx = "i" + std::to_string(i);
-		INDT_2 << "for( uint32_t " << idx << "=0; ";
-		dst <<            idx << "<" << input->data_dim[i] << "; ";
-		dst <<            idx <<"++ ) {" << std::endl;
+        for( unsigned i = start; i<input->data_dim.size(); i++) {
+                std::string idx = "i" + std::to_string(i);
+                INDT_2 << "for( uint32_t " << idx << "=0; ";
+                dst <<            idx << "<" << input->data_dim[i] << "; ";
+                dst <<            idx <<"++ ) {" << std::endl;
 	}
 	 INDT_3 << type << " d = input" << idxs << ";" <<std::endl;
 	 INDT_3 << "output"<< idxs << " = scale[c] * (d-mean) / sqrt(var + epsilon) + B[c];" << std::endl;
 
-	for( unsigned i = 2; i<input->data_dim.size(); i++)
-		INDT_2 << "}" << std::endl;
+        for( unsigned i = start; i<input->data_dim.size(); i++)
+                INDT_2 << "}" << std::endl;
 
 
 	// close channel & batch
-	INDT_1 << "}" << std::endl;
-	INDT_1 << "}" << std::endl;
+        INDT_1 << "}" << std::endl;
+        if( has_batch )
+                INDT_1 << "}" << std::endl;
 }
 }
 

--- a/src/nodes/lrn.h
+++ b/src/nodes/lrn.h
@@ -71,16 +71,18 @@ class LRN : public Node {
 		INDT_1 << "   size:  " << size << std::endl;
 		INDT_1 << "*/" << std::endl;
 
-		INDT_1 << "int N = " << X->data_dim[0] << ";" << std::endl;
-		INDT_1 << "int C = " << X->data_dim[1] << ";" << std::endl;
+                bool has_batch = X->rank() == 3 ? false : true;
+                INDT_1 << "int N = " << (has_batch ? std::to_string(X->data_dim[0]) : "1") << ";" << std::endl;
+                INDT_1 << "int C = " << (has_batch ? std::to_string(X->data_dim[1]) : std::to_string(X->data_dim[0])) << ";" << std::endl;
 		INDT_1 << "float alpha = " << alpha << ";" << std::endl;
 		INDT_1 << "float beta = " << beta << ";" << std::endl;
 		INDT_1 << "float bias = " << bias << ";" << std::endl;
 		INDT_1 << "int size = " << size << ";" << std::endl;
 
 		// loop over batches and channels
-		INDT_1 << "for (unsigned n=0; n<N; n++) {" << std::endl;
-		INDT_1 << "for (unsigned c=0; c<C; c++) {" << std::endl;
+                if( has_batch )
+                        INDT_1 << "for (unsigned n=0; n<N; n++) {" << std::endl;
+                INDT_1 << "for (unsigned c=0; c<C; c++) {" << std::endl;
 
 		// loop over the data channels
 		std::string y_idx="";
@@ -108,8 +110,8 @@ class LRN : public Node {
 
 
 		// close loop over all dimensions
-		for( unsigned r=0; r< X->rank(); r++)
-			INDT_1 << "}" << std::endl;
+                for( unsigned r= has_batch?0:1; r< X->rank(); r++)
+                        INDT_1 << "}" << std::endl;
 	}
 };
 }

--- a/src/nodes/pooling.h
+++ b/src/nodes/pooling.h
@@ -45,9 +45,9 @@ class Pooling : public SpatialFilter {
 	}
 	virtual std::vector<int> resolve_output_size(void) override
 	{
-		std::vector<int> rv;
-		rv.push_back(get_X()->data_dim[0]);//batch
-		rv.push_back(get_X()->data_dim[1]);//channel
+               std::vector<int> rv;
+               rv.push_back(input_batch());
+               rv.push_back(input_channels());
 	
 		unsigned data_dims = get_numDataDim();
 		std::vector<int> pad_shapes;
@@ -56,11 +56,12 @@ class Pooling : public SpatialFilter {
 		}
 		// Calculate output shape. Pads are now calculated
 		// for those auto_pad modes that need them.
-		for( unsigned i=2; i<get_X()->data_dim.size(); i++ ) {
-			int d;
-			int in_dim = get_X()->data_dim[i];
-			int kernel = kernel_shape[i-2];
-			int dilation = dilations.size()==0 ? 1 : dilations[i-2];
+               unsigned x_start = has_batch_dim() ? 2 : 1;
+               for( unsigned i=x_start; i<get_X()->data_dim.size(); i++ ) {
+                       int d;
+                       int in_dim = input_dim(i - x_start);
+                       int kernel = kernel_shape[i-2];
+                       int dilation = dilations.size()==0 ? 1 : dilations[i-2];
 			int stride = strides[i-2];
 			if ( auto_pad == "NOTSET" ) {
 				//int pad_sh = pad_shapes[i-2];
@@ -101,8 +102,8 @@ class Pooling : public SpatialFilter {
 			// The auto_pad attribute for AveragePool is deprecated anyway. Probably just for this confusion.
 			// This tries to be some sort of band-aid: assume the output size is the same as input size
 			// which is the usual(?) reason to use "same" padding on the network design level. 
-			int input_size = get_X()->data_dim[i+2];
-			int output_size = get_Y()->data_dim[i+2];
+                       int input_size = input_dim(i);
+                       int output_size = get_Y()->data_dim[i+2];
 			int pad_shape = (output_size - 1) * strides[i] + (( kernel_shape[i] -1) * dilations[i]+1) - input_size; 
 			pads[i] = pad_shape/2;
 			pads[i+data_dims] = pad_shape/2;

--- a/src/nodes/spatialfilter.h
+++ b/src/nodes/spatialfilter.h
@@ -35,8 +35,27 @@ class SpatialFilter : public Node {
 		else
 			return nullptr;
 	}
-	const Tensor* get_Y(void) const { return get_output_tensor(0); }
-	uint32_t get_numDataDim(void) const {return get_X()->rank() - 2; }
+       const Tensor* get_Y(void) const { return get_output_tensor(0); }
+       bool has_batch_dim(void) const {
+               unsigned nd = kernel_shape.size();
+               if( nd == 0 && get_W() )
+                       nd = get_W()->rank() - 2;
+               return get_X()->rank() == nd + 2;
+       }
+       uint32_t get_numDataDim(void) const {
+               if( kernel_shape.size() )
+                       return kernel_shape.size();
+               return has_batch_dim() ? get_X()->rank()-2 : get_X()->rank()-1;
+       }
+       unsigned input_batch(void) const {
+               return has_batch_dim() ? get_X()->data_dim[0] : 1;
+       }
+       unsigned input_channels(void) const {
+               return has_batch_dim() ? get_X()->data_dim[1] : get_X()->data_dim[0];
+       }
+       unsigned input_dim(unsigned idx) const {
+               return has_batch_dim() ? get_X()->data_dim[2+idx] : get_X()->data_dim[1+idx];
+       }
 
 	virtual void parseAttributes( onnx::NodeProto &node ) override {
 		for( const auto& a : node.attribute() ) {
@@ -106,14 +125,15 @@ class SpatialFilter : public Node {
 
 	virtual std::vector<int> resolve_output_size(void)
 	{
-		std::vector<int> rv;
-		unsigned num_data_dim = get_numDataDim();
-		rv.push_back(get_X()->data_dim[0]);//batch size
-		rv.push_back(get_W()->data_dim[0]);//"number of feature maps"
+               std::vector<int> rv;
+               unsigned num_data_dim = get_numDataDim();
+               rv.push_back(input_batch());
+               rv.push_back(get_W()->data_dim[0]);
 
-		for( unsigned dim=0, xdim=2;
-		     dim < num_data_dim;
-		     dim++, xdim++) {
+               unsigned x_start = has_batch_dim() ? 2 : 1;
+               for( unsigned dim=0, xdim=x_start;
+                    dim < num_data_dim;
+                    dim++, xdim++) {
 			int outdim;
 			// Not sure if the naming is correct. Here
 			// kernel: the (number of) weights of the filter
@@ -125,11 +145,11 @@ class SpatialFilter : public Node {
 			// From ONNX Operators.md:
 			// SAME_UPPER or SAME_LOWER mean pad the input so that the output spatial size match the input.
 			// "match" here means "is equal".
-			if( auto_pad == "SAME_UPPER" || auto_pad == "SAME_LOWER" )
-				outdim = get_X()->data_dim[xdim];
-			else if( auto_pad == "NOTSET" || auto_pad == "VALID") {
-				//padded input
-				int input_size = get_X()->data_dim[xdim] + pads[dim]+pads[dim+num_data_dim];
+                        if( auto_pad == "SAME_UPPER" || auto_pad == "SAME_LOWER" )
+                                outdim = input_dim(dim);
+                        else if( auto_pad == "NOTSET" || auto_pad == "VALID") {
+                                //padded input
+                                int input_size = input_dim(dim) + pads[dim]+pads[dim+num_data_dim];
 				// [ 0 1 2 3 4 5 6 7 8 9  ]
 				//                |kern=3|
 				// last output=7
@@ -195,32 +215,33 @@ class SpatialFilter : public Node {
 	virtual void print_output_cell_finalize(std::ostream &dst, const std::string &y_idx="") const = 0;
 	void print_loop_with_padding_checks(std::ostream &dst) const
 	{
-		unsigned n_data_dims = get_numDataDim();
-		unsigned batch_size = get_X()->data_dim[0];
-		unsigned channels = get_X()->data_dim[1];
-		unsigned maps=get_Y()->data_dim[1];
+               unsigned n_data_dims = get_numDataDim();
+               unsigned batch_size = input_batch();
+               unsigned channels = input_channels();
+               unsigned maps=get_Y()->data_dim[1];
 
 		/* Create various indexing strings. This makes generating the loops much cleaner,
 		 * and makes possible the code sharing in child classes. */
-		std::string x_idx = "[b][c]";
-		std::string in_kern_idxs = "[b][c]";
-		std::string y_idx = "[b][m]";
-		for( unsigned i = 0; i<n_data_dims; i++) {
-			std::string i_str = std::to_string(i);
-			x_idx += "[i" + i_str + "]";
-			y_idx += "[o" + i_str + "]";
-			in_kern_idxs += "[ii" + i_str + "]";
-		}
+               std::string x_idx = has_batch_dim()? "[b][c]" : "[c]";
+               std::string in_kern_idxs = has_batch_dim()? "[b][c]" : "[c]";
+               std::string y_idx = has_batch_dim()? "[b][m]" : "[m]";
+               for( unsigned i = 0; i<n_data_dims; i++) {
+                       std::string i_str = std::to_string(i);
+                       x_idx += "[i" + i_str + "]";
+                       y_idx += "[o" + i_str + "]";
+                       in_kern_idxs += "[ii" + i_str + "]";
+               }
 
 		/* Create the loops over batches and channels.
 		 * In case this SpatialFilter has a weights input (w), this first loop is over
 		 * output channels (M). Othervise input channels==outputchannels, and it is named C
 		 */
-		INDT_1 << "for( uint32_t b=0; b<" << batch_size << "; b++ ) {" << std::endl;
-		if( options.quantize ) {
-			INDT_2 << "int32_t batch_min = INT32_MAX;" << std::endl;
-			INDT_2 << "int32_t batch_max = INT32_MIN;" << std::endl;
-		}
+               if( has_batch_dim() )
+                       INDT_1 << "for( uint32_t b=0; b<" << batch_size << "; b++ ) {" << std::endl;
+               if( options.quantize ) {
+                       INDT_2 << "int32_t batch_min = INT32_MAX;" << std::endl;
+                       INDT_2 << "int32_t batch_max = INT32_MIN;" << std::endl;
+               }
 		if( direct_channel_map() )
 			INDT_1 << "for( uint32_t m=0, c=0; m<" << maps << "; m++, c=m) {" << std::endl;
 		else if( get_W() && group > 1 ) {
@@ -263,10 +284,10 @@ class SpatialFilter : public Node {
 		// check for out-of-input reading (i.e. read a pad)
 		for( unsigned i = 0; i<n_data_dims; i++) {
 			std::string i_str = std::to_string(i);
-			INDT_4 <<  "int ii" << i_str << " = i" << i_str << "+k" << i_str <<" * " << dilations[i] <<";" << std::endl;
-			INDT_4 <<  "if( ii" << i_str << "<0) continue;" << std::endl;
-			INDT_4 <<  "if( ii" << i_str << ">=" << get_X()->data_dim[2+i] << ") continue;" << std::endl;
-		}
+                        INDT_4 <<  "int ii" << i_str << " = i" << i_str << "+k" << i_str <<" * " << dilations[i] <<";" << std::endl;
+                        INDT_4 <<  "if( ii" << i_str << "<0) continue;" << std::endl;
+                        INDT_4 <<  "if( ii" << i_str << ">=" << input_dim(i) << ") continue;" << std::endl;
+                }
 
 		print_output_cell_calc(dst, in_kern_idxs, "", y_idx);
 
@@ -284,11 +305,12 @@ class SpatialFilter : public Node {
 			INDT_2 << "} /* o */" << std::endl;
 
 		// close loops over batches and output channels
-		INDT_1 << "} /* m */" << std::endl;
-		if( direct_channel_map() == false && group > 1 )
-			INDT_2 << "} /* g */" << std::endl;
-		INDT_1 << "} /* b */" << std::endl;
-	}
+               INDT_1 << "} /* m */" << std::endl;
+               if( direct_channel_map() == false && group > 1 )
+                       INDT_2 << "} /* g */" << std::endl;
+               if( has_batch_dim() )
+                       INDT_1 << "} /* b */" << std::endl;
+               }
 };
 }
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -169,9 +169,30 @@ void print_loops_over_dims(std::ostream &dst, const toC::Tensor *t, std::string 
 }
 void print_loop_closes_over_dims(std::ostream &dst, const toC::Tensor *t, unsigned indents)
 {
-	for( unsigned dim=0; dim<t->rank(); dim++) {
-		for(unsigned i=0; i<indents; i++)
-			dst << "\t";
-		dst << "}"<< std::endl;
-	}
+        for( unsigned dim=0; dim<t->rank(); dim++) {
+                for(unsigned i=0; i<indents; i++)
+                        dst << "\t";
+                dst << "}"<< std::endl;
+        }
+}
+
+unsigned tensor_batch_size(const toC::Tensor *t, unsigned num_spatial)
+{
+        if( t->rank() == num_spatial + 1 )
+                return 1;
+        return t->data_dim[0];
+}
+
+unsigned tensor_channel_size(const toC::Tensor *t, unsigned num_spatial)
+{
+        if( t->rank() == num_spatial + 1 )
+                return t->data_dim[0];
+        return t->data_dim[1];
+}
+
+unsigned tensor_spatial_dim(const toC::Tensor *t, unsigned num_spatial, unsigned idx)
+{
+        if( t->rank() == num_spatial + 1 )
+                return t->data_dim[1 + idx];
+        return t->data_dim[2 + idx];
 }

--- a/src/util.h
+++ b/src/util.h
@@ -49,3 +49,11 @@ void print_loops_over_dims(std::ostream &dst, const toC::Tensor *, std::string p
 // and the same for the loop closes
 void print_loop_closes_over_dims(std::ostream &dst, const toC::Tensor *t, unsigned indents);
 
+/* Helper functions to interpret tensors that may omit the batch dimension.
+ * num_spatial is the expected number of spatial dimensions for the operator.
+ * If the tensor's rank equals num_spatial + 1, the batch dimension is missing
+ * and is assumed to be 1. */
+unsigned tensor_batch_size(const toC::Tensor *t, unsigned num_spatial);
+unsigned tensor_channel_size(const toC::Tensor *t, unsigned num_spatial);
+unsigned tensor_spatial_dim(const toC::Tensor *t, unsigned num_spatial, unsigned idx);
+


### PR DESCRIPTION
## Summary
- add helpers for tensors that omit batch dimension
- update spatial filter logic
- adjust pooling and global pooling ops
- adapt batch/instance normalization and LRN
- handle ConvTranspose with optional batch

## Testing
- `cmake ..` *(fails: missing cmake_timestamp and Protobuf)*

------
https://chatgpt.com/codex/tasks/task_e_6857a4ab096c832db542b42011796b4c